### PR TITLE
SLING-11596 Mark the DefaultLoginsHealthCheck as deprecated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheck.java
+++ b/src/main/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheck.java
@@ -39,14 +39,17 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** {@link HealthCheck} that runs an arbitrary script. */
+/** {@link HealthCheck} that runs an arbitrary script. 
+ * @deprecated for SLING-11446 - Moved this to the org.apache.sling.auth.core bundle
+ */
 @Component(service = HealthCheck.class, name = "org.apache.sling.hc.support.DefaultLoginsHealthCheck", configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = DefaultLoginsHealthCheck.Config.class, factory = true)
+@Deprecated
 public class DefaultLoginsHealthCheck implements HealthCheck {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultLoginsHealthCheck.class);
 
-    public static final String HC_LABEL = "Health Check: Default Logins";
+    public static final String HC_LABEL = "Health Check: Default Logins (deprecated)";
 
     @ObjectClassDefinition(name = HC_LABEL, description = "Expects default logins to fail, used to verify that they are disabled on production systems")
     @interface Config {
@@ -63,7 +66,7 @@ public class DefaultLoginsHealthCheck implements HealthCheck {
         String[] logins() default "logins";
 
         @AttributeDefinition
-        String webconsole_configurationFactory_nameHint() default "Default Logins Check: {logins}";
+        String webconsole_configurationFactory_nameHint() default "Default Logins Check (deprecated): {logins}";
     }
 
     private List<String> logins;
@@ -75,6 +78,7 @@ public class DefaultLoginsHealthCheck implements HealthCheck {
     protected void activate(Config config) {
         this.logins = Arrays.asList(config.logins());
         LOG.info("Activated, logins={}", logins);
+        LOG.warn("This is deprecated.  Please use the component from the org.apache.sling.auth.core bundle instead.");
     }
 
     @Override

--- a/src/main/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheck.java
+++ b/src/main/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheck.java
@@ -66,7 +66,7 @@ public class DefaultLoginsHealthCheck implements HealthCheck {
         String[] logins() default "logins";
 
         @AttributeDefinition
-        String webconsole_configurationFactory_nameHint() default "Default Logins Check (deprecated): {logins}";
+        String webconsole_configurationFactory_nameHint() default "Default Logins Check (deprecated): {logins}"; // NOSONAR
     }
 
     private List<String> logins;
@@ -78,7 +78,7 @@ public class DefaultLoginsHealthCheck implements HealthCheck {
     protected void activate(Config config) {
         this.logins = Arrays.asList(config.logins());
         LOG.info("Activated, logins={}", logins);
-        LOG.warn("This is deprecated.  Please use the component from the org.apache.sling.auth.core bundle instead.");
+        LOG.warn("This is deprecated. Please use the component from the org.apache.sling.auth.core bundle instead.");
     }
 
     @Override

--- a/src/test/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheckTest.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheckTest.java
@@ -34,6 +34,10 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+/**
+ * @deprecated for SLING-11446 - Moved this to the org.apache.sling.auth.core bundle
+ */
+@Deprecated
 public class DefaultLoginsHealthCheckTest {
     
     private Result getTestResult(String login) throws Exception {

--- a/src/test/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheckTest.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/DefaultLoginsHealthCheckTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import ch.qos.logback.classic.Level;
+
 /**
  * @deprecated for SLING-11446 - Moved this to the org.apache.sling.auth.core bundle
  */
@@ -65,9 +67,26 @@ public class DefaultLoginsHealthCheckTest {
     public void testHealthCheckFails() throws Exception {
         assertFalse("Expecting failed check", getTestResult("admin:admin").isOk());
     }
-    
+
     @Test
     public void testHealthCheckSucceeds() throws Exception {
         assertTrue("Expecting successful check", getTestResult("FOO:bar").isOk());
     }
+
+    @Test
+    public void testHealthCheckDeprecatedWarning() throws Exception {
+        final DefaultLoginsHealthCheck c = new DefaultLoginsHealthCheck();
+        DefaultLoginsHealthCheck.Config config = Mockito.mock(DefaultLoginsHealthCheck.Config.class);
+        Mockito.when(config.logins()).thenReturn(new String[] {"admin:admin"});
+
+        try (LogCapture capture = new LogCapture("org.apache.sling.hc.support.impl.DefaultLoginsHealthCheck", true)) {
+            // this should log a deprecation warning
+            c.activate(config);
+
+            // verify the warning was logged
+            capture.assertContains(Level.WARN, "This is deprecated. Please use the component from the org.apache.sling.auth.core bundle instead.");
+        }
+
+    }
+
 }

--- a/src/test/java/org/apache/sling/hc/support/impl/LogCapture.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/LogCapture.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.hc.support.impl;
+
+import static org.junit.Assert.fail;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/** 
+ * Capture logs for testing 
+ * 
+ * Initially cloned from: https://github.com/apache/sling-org-apache-sling-graphql-core/blob/0b1c1dd72ed04324ea84d2227c3223ec65b0b21e/src/test/java/org/apache/sling/graphql/core/util/LogCapture.java
+ */
+class LogCapture extends ListAppender<ILoggingEvent> implements AutoCloseable {
+    private final boolean verboseFailure;
+    private Logger logger;
+
+    public LogCapture(String loggerName, boolean verboseFailure) {
+        this.verboseFailure = verboseFailure;
+        logger = (Logger) LoggerFactory.getLogger(loggerName);
+        logger.setLevel(Level.ALL);
+        setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.addAppender(this);
+        start();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (logger != null) {
+            logger.detachAppender(this);
+        }
+    }
+
+    public boolean anyMatch(Predicate<ILoggingEvent> p) {
+        return this.list.stream().anyMatch(p);
+    }
+
+    public void assertContains(Level atLevel, String ... substrings) {
+        Stream.of(substrings).forEach(substring -> {
+            if(!anyMatch(event -> event.getLevel() == atLevel && event.getFormattedMessage().contains(substring))) {
+                if(verboseFailure) {
+                    fail(String.format("No log message contains [%s] in log\n%s", substring, this.list.toString()));
+                } else {
+                    fail(String.format("No log message contains [%s]", substring));
+                }
+            }
+        });
+    }
+}

--- a/src/test/java/org/apache/sling/hc/support/impl/SetField.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/SetField.java
@@ -19,6 +19,10 @@ package org.apache.sling.hc.support.impl;
 
 import java.lang.reflect.Field;
 
+/**
+ * @deprecated for SLING-11446 - Moved this to the org.apache.sling.auth.core bundle
+ */
+@Deprecated
 public class SetField {
     
     public static void set(Object o, String name, Object value) throws Exception {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{dd.MM.yyyy HH:mm:ss} *%-5p* [%t] %c{1}: %m \(%F, line %L\)%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.apache.jackrabbit" level="WARN"/>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Mark the DefaultLoginsHealthCheck as deprecated and provide instructions to use the equivalent functionality from the auth core bundle instead.

Log a warning message if the deprecated DefaultLoginsHealthCheck ever gets invoked.