### PR TITLE
SLING-11445 Mark the ScriptedHealthCheck as deprecated

### DIFF
--- a/src/main/java/org/apache/sling/hc/support/impl/ScriptedHealthCheck.java
+++ b/src/main/java/org/apache/sling/hc/support/impl/ScriptedHealthCheck.java
@@ -67,14 +67,19 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** {@link HealthCheck} that runs an arbitrary script. */
+/** 
+ * {@link HealthCheck} that runs an arbitrary script.
+ * 
+ * @deprecated for SLING-11445 -  use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead
+ */
 @Component(service = HealthCheck.class, name = "org.apache.sling.hc.support.ScriptedHealthCheck", configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = ScriptedHealthCheck.Config.class, factory = true)
+@Deprecated
 public class ScriptedHealthCheck implements HealthCheck {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScriptedHealthCheck.class);
 
-    public static final String HC_LABEL = "Health Check: Sling Script";
+    public static final String HC_LABEL = "Health Check: Sling Script (deprecated)";
 
     public static final String JCR_FILE_URL_PREFIX = "jcr:";
     private static final String JCR_CONTENT = "/jcr:content";
@@ -106,7 +111,7 @@ public class ScriptedHealthCheck implements HealthCheck {
         String scriptUrl() default "";
 
         @AttributeDefinition
-        String webconsole_configurationFactory_nameHint() default "Scripted HC: {hc.name} (tags: {hc.tags}) {scriptUrl} language: {language}"; // NOSONAR
+        String webconsole_configurationFactory_nameHint() default "Scripted HC (deprecated): {hc.name} (tags: {hc.tags}) {scriptUrl} language: {language}"; // NOSONAR
     }
 
     private String language;
@@ -138,6 +143,7 @@ public class ScriptedHealthCheck implements HealthCheck {
         LOG.info("Activated Scripted HC {} with {}", config.hc_name(),
                 (StringUtils.isNotBlank(script) ? "script " + script : "script url " + scriptUrl));
 
+        LOG.warn("This is deprecated. Please use the use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead.");
     }
 
     @Override

--- a/src/test/java/org/apache/sling/hc/support/impl/ScriptedHealthCheckTest.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/ScriptedHealthCheckTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The SF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.sling.hc.support.impl;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+
+import ch.qos.logback.classic.Level;
+
+/**
+ * @deprecated for SLING-11445 -  use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead
+ */
+@Deprecated
+public class ScriptedHealthCheckTest {
+
+    @Test
+    public void testHealthCheckDeprecatedWarning() throws Exception {
+        final ScriptedHealthCheck c = new ScriptedHealthCheck();
+        ScriptedHealthCheck.Config config = Mockito.mock(ScriptedHealthCheck.Config.class);
+        Mockito.when(config.language()).thenReturn("groovy");
+
+        BundleContext bc = Mockito.mock(BundleContext.class);
+        try (LogCapture capture = new LogCapture("org.apache.sling.hc.support.impl.ScriptedHealthCheck", true)) {
+            // this should log a deprecation warning
+            c.activate(bc, config);
+
+            // verify the warning was logged
+            capture.assertContains(Level.WARN, "This is deprecated. Please use the use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead.");
+        }
+
+    }
+
+}

--- a/src/test/java/org/apache/sling/hc/support/impl/it/HCSupportTestSupport.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/it/HCSupportTestSupport.java
@@ -46,6 +46,10 @@ import org.ops4j.pax.exam.options.ModifiableCompositeOption;
 import org.ops4j.pax.exam.options.OptionalCompositeOption;
 import org.ops4j.pax.exam.options.extra.VMOption;
 
+/**
+ * @deprecated for SLING-11445 -  use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead
+ */
+@Deprecated
 public class HCSupportTestSupport extends TestSupport {
 
     @Inject

--- a/src/test/java/org/apache/sling/hc/support/impl/it/ScriptedHealthCheckIT.java
+++ b/src/test/java/org/apache/sling/hc/support/impl/it/ScriptedHealthCheckIT.java
@@ -50,9 +50,11 @@ import org.ops4j.pax.exam.util.PathUtils;
 
 /**
  * Tests for SLING-11141
+ * @deprecated for SLING-11445 -  use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
+@Deprecated
 public class ScriptedHealthCheckIT extends HCSupportTestSupport {
 
     @Inject


### PR DESCRIPTION
Mark the ScriptedHealthCheck as deprecated and provide instructions to use the equivalent functionality from the org.apache.felix.healthcheck.generalchecks bundle instead.

Log a warning message if the deprecated ScriptedHealthCheck ever gets invoked.